### PR TITLE
Update README with how to host the Web App in GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Web App must be hosted somewhere. Hosting it on a GitHub repository is a qui
 2. On the repository: Settings > Pages:
     - Source: Deploy from a branch
     - Branch: master, / (root), Save
-3. Wait a few minutes for the web to be deployed. It will be available at: `https://{github-username}.github.io/{repository-name}/{location-inside-repository}`. In this case: `https://david-lor.github.io/telegram-web-app-bot-example.github.io/index.html`
+3. Wait a few minutes for the web to be deployed. It will be available at: `https://{github-username}.github.io/{repository-name}/{location-inside-repository}`. In this case: `https://revenkroz.github.io/telegram-web-app-bot-example.github.io/index.html`
 
 #### 1. Show the user a button to open a Web App. There are two ways:
 
@@ -26,14 +26,14 @@ The Web App must be hosted somewhere. Hosting it on a GitHub repository is a qui
     1. Go to [Bot Father](https://t.me/BotFather)
     2. Select your bot
     3. `Bot Settings` — `Menu Button` — `Specify..`/`Edit menu button URL`
-    4. Send a URL to your Web App (in this case, `https://david-lor.github.io/telegram-web-app-bot-example.github.io/index.html`)
+    4. Send a URL to your Web App (in this case, `https://revenkroz.github.io/telegram-web-app-bot-example.github.io/index.html`)
 
 2. The second way is to send a button with the data that contains field `web_app` with a URL to a Web App:
     ```json
     {
         "text": "Test web_app",
         "web_app": {
-            "url": "https://david-lor.github.io/telegram-web-app-bot-example.github.io/index.html"
+            "url": "https://revenkroz.github.io/telegram-web-app-bot-example.github.io/index.html"
         }
     }
     ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Web App must be hosted somewhere. Hosting it on a GitHub repository is a qui
 2. On the repository: Settings > Pages:
     - Source: Deploy from a branch
     - Branch: master, / (root), Save
-3. Wait a few minutes for the web to be deployed. It will be available at: `https://{github-username}.github.io/{repository-name}/{location-inside-repository}`. In this case: `https://revenkroz.github.io/telegram-web-app-bot-example.github.io/index.html`
+3. Wait a few minutes for the web to be deployed. It will be available at: `https://{github-username}.github.io/{repository-name}/{location-inside-repository}`. In this case: `https://revenkroz.github.io/telegram-web-app-bot-example/index.html`
 
 #### 1. Show the user a button to open a Web App. There are two ways:
 
@@ -26,14 +26,14 @@ The Web App must be hosted somewhere. Hosting it on a GitHub repository is a qui
     1. Go to [Bot Father](https://t.me/BotFather)
     2. Select your bot
     3. `Bot Settings` — `Menu Button` — `Specify..`/`Edit menu button URL`
-    4. Send a URL to your Web App (in this case, `https://revenkroz.github.io/telegram-web-app-bot-example.github.io/index.html`)
+    4. Send a URL to your Web App (in this case, `https://revenkroz.github.io/telegram-web-app-bot-example/index.html`)
 
 2. The second way is to send a button with the data that contains field `web_app` with a URL to a Web App:
     ```json
     {
         "text": "Test web_app",
         "web_app": {
-            "url": "https://revenkroz.github.io/telegram-web-app-bot-example.github.io/index.html"
+            "url": "https://revenkroz.github.io/telegram-web-app-bot-example/index.html"
         }
     }
     ```

--- a/README.md
+++ b/README.md
@@ -10,20 +10,30 @@ Example HTML-file that contains a basic interaction with Telegram Web Apps API. 
 
 ## Quick setup
 
+#### 0. Host the Web App in GitHub Pages
+
+The Web App must be hosted somewhere. Hosting it on a GitHub repository is a quick, free way to do it:
+
+1. Create a repository (or fork this one)
+2. On the repository: Settings > Pages:
+    - Source: Deploy from a branch
+    - Branch: master, / (root), Save
+3. Wait a few minutes for the web to be deployed. It will be available at: `https://{github-username}.github.io/{repository-name}/{location-inside-repository}`. In this case: `https://david-lor.github.io/telegram-web-app-bot-example.github.io/index.html`
+
 #### 1. Show the user a button to open a Web App. There are two ways:
 
 1. Show the user a special menu button (near the message input field):
     1. Go to [Bot Father](https://t.me/BotFather)
     2. Select your bot
     3. `Bot Settings` — `Menu Button` — `Specify..`/`Edit menu button URL`
-    4. Send a URL to your Web App (e.g. `https://example.com/telegram-web-app/index.html`)
+    4. Send a URL to your Web App (in this case, `https://david-lor.github.io/telegram-web-app-bot-example.github.io/index.html`)
 
 2. The second way is to send a button with the data that contains field `web_app` with a URL to a Web App:
     ```json
     {
         "text": "Test web_app",
         "web_app": {
-            "url": "https://example.com/telegram-web-app/index.html"
+            "url": "https://david-lor.github.io/telegram-web-app-bot-example.github.io/index.html"
         }
     }
     ```


### PR DESCRIPTION
For a more detailed and ready-to-use example, I've documented on the README how to configure a GitHub Repository as a GitHub Page, and use the `index.html` hosted in it as the Telegram Bot Web App menu button. If you want to merge it, you may want to setup this project as a GitHub Page as well, so the example works as documented (: