### PR TITLE
Adding  isVersionAtLeast and doesntSupport function

### DIFF
--- a/index.html
+++ b/index.html
@@ -607,6 +607,21 @@
                 }
             });
         },
+        isVersionAtLeast(version) {
+            return Telegram.WebApp.isVersionAtLeast(version);
+        },
+        //version to string Example: '6.9'
+        doesntSupport(version) {
+            // console.log("version: " + version);
+            // console.log("realVersion: " + this.version());
+            // console.log("doesntSupport: " + this.isVersionAtLeast(version));
+            if (!this.isVersionAtLeast(version)) {
+                Telegram.WebApp.showAlert('This feature is not supported in this version of Telegram', function () {
+                    Telegram.WebApp.close();
+                });
+                throw new Error('This feature is not supported in this version of Telegram');
+            }
+        },
         showPopup() {
             Telegram.WebApp.showPopup({
                 title  : 'Popup title',


### PR DESCRIPTION
I added two new features. One is `isVersionAtLeast` to check the version.

If the WebApp needs to be used in a certain version and a version above it, it can use the `doesntSupport` function.